### PR TITLE
Update to-value.ts

### DIFF
--- a/packages/engine/src/model/transform/to-value.ts
+++ b/packages/engine/src/model/transform/to-value.ts
@@ -8,7 +8,7 @@ import { escape, unescape } from '../../utils';
 export const toValue = (node: Node, filter?: (node: Node) => false | void) => {
 	if (Text.isText(node)) {
 		const { text } = node;
-		return unescape(text)
+		return escape(text)
 			.replace(/\u00a0/g, ' ')
 			.replace(/\u200b/g, '');
 	} else if (Element.isElement(node)) {


### PR DESCRIPTION
作为做底层的数据承载体结构text，在解析时应该进行编码，将标签符号转义，这样就可以解决像行内样式code这类直接渲染的插件会将输入的html标签吞掉的问题